### PR TITLE
Fix rare bug where the tensor can end up being empty on calculation

### DIFF
--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -143,7 +143,9 @@ def generate_emissions(
     ]  # removing the context
     emissions = emissions.flatten(0, 1)
     if extention > 0:
-        emissions = emissions[: -time_to_frame(extention / SAMPLING_FREQ), :]
+        new_emissions = emissions[: -time_to_frame(extention / SAMPLING_FREQ), :]
+        if new_emissions.size(0) > 0:  # Only reassign emissions if the new tensor is not empty
+            emissions = new_emissions
 
     emissions = torch.log_softmax(emissions, dim=-1)
     emissions = torch.cat(


### PR DESCRIPTION
Had a rare bug happen from a list of over 200 files where on one file, the tensor would become empty after this calculation during the condition ( I won't pretend to understand the math). If it was empty, `generate_emissions` would throw an error. I imagine the calculation is crucial in having the precise timestamps for the words, but slightly off timestamps is better than no file at all.