### PR TITLE
An option to use 'custom' user defined <star> tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ctc-forced-aligner --audio_path "path/to/audio.wav" --text_path "path/to/text.tx
 | `--language` | Language in ISO 639-3 code | Required |
 | `--romanize` | Enable romanization for non-latin scripts or for multilingual models regardless of the language, required when using the default model| False |
 | `--split_size` | Alignment granularity: "sentence", "word", or "char" | "word" |
-| `--star_frequency` | Frequency of `<star>` token: "segment" or "edges" | "edges" |
+| `--star_frequency` | Frequency of `<star>` token: "custom", "segment" or "edges" | "edges" |
 | `--merge_threshold` | Merge threshold for segment merging | 0.00 |
 | `--alignment_model` | Name of the alignment model | [MahmoudAshraf/mms-300m-1130-forced-aligner](https://huggingface.co/MahmoudAshraf/mms-300m-1130-forced-aligner) |
 | `--compute_dtype` | Compute dtype for inference | "float32" |

--- a/ctc_forced_aligner/align.py
+++ b/ctc_forced_aligner/align.py
@@ -59,11 +59,12 @@ def cli():
         "--star_frequency",
         type=str,
         default="edges",
-        choices=["segment", "edges"],
+        choices=["segment", "edges", "custom"],
         help="The frequency of the <star> token in the text."
         "Star token increases the accuracy of the alignment but also increases segment fragmentation."
         "segment adds <star> token after each segment."
         "edges adds <star> token at the start and end of the text."
+        "custom uses the <star> tokens predefined by user in the input text"
         "use --merge_threshold to merge segments that are closer than the threshold.",
     )
     parser.add_argument(


### PR DESCRIPTION
 These changes stops the stripping of <star> tokens in the text inputted to the aligner if star_frequency is set to "custom".