### PR TITLE
close #49 alignment_utils: Fix batch_size param logic

### DIFF
--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -116,7 +116,7 @@ def generate_emissions(
     context_length=2,
     batch_size=4,
 ):
-    batch_size = min(batch_size, 1)
+    batch_size = max(batch_size, 1)
     window = int(window_length * SAMPLING_FREQ)
     if audio_waveform.size(0) > window:
         extension = 0


### PR DESCRIPTION
Corrected arg check logic that used min(batch_size, 1) which inadvertently always reset batch_size to 1

Rationale: batch_size was being set to a maximum of 1 in generate_emissions. This under utilizes the compute available in the most compute intensive operation in the ctc alignment workflow.