### PR TITLE
Fixed installation using pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.egg-info
 *.so
+build/

--- a/ctc_forced_aligner/__init__.py
+++ b/ctc_forced_aligner/__init__.py
@@ -17,4 +17,4 @@ from .text_utils import (
     text_normalize,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from pybind11.setup_helpers import Pybind11Extension, build_ext
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
 
 ext_modules = [
@@ -11,6 +11,15 @@ ext_modules = [
 ]
 
 setup(
+    name="ctc_forced_aligner",
+    version="0.3.0",
+    packages=find_packages(),
     ext_modules=ext_modules,
+    package_data={
+        "ctc_forced_aligner": ["punctuations.lst"],
+        "README.md": ["README.md"],
+        "LICENSE": ["LICENSE"],
+    },
+    include_package_data=True,
     cmdclass={"build_ext": build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ ext_modules = [
 
 setup(
     name="ctc_forced_aligner",
-    version="0.3.0",
+    version="0.3.1",
     packages=find_packages(),
     ext_modules=ext_modules,
     package_data={


### PR DESCRIPTION
I wanted to use [whisper-diarizion](https://github.com/MahmoudAshraf97/whisper-diarization) but when I ran `pip install -c constraints.txt -r requirements.txt` it installs everything except this package, so I tried to fix it. With this changes, pip installs this package correctly.