### PR TITLE
fix: derive <star> target index from emission vocab size

### DIFF
--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -266,6 +266,8 @@ def get_alignments(
     dictionary = _build_alignment_dictionary(tokenizer, emission_vocab_size)
 
     token_indices = [dictionary[c] for c in " ".join(tokens).split(" ") if c in dictionary]
+    if not token_indices:
+        raise ValueError("No valid tokens found in the dictionary for the given transcript.")
 
     blank_id = dictionary.get("<blank>", tokenizer.pad_token_id)
     if blank_id >= emissions.size(-1) or blank_id < 0:

--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -247,9 +247,9 @@ def forced_align(
 
 
 def _build_alignment_dictionary(tokenizer, emission_vocab_size: int) -> dict[str, int]:
-    dictionary = {k.lower(): v for k, v in tokenizer.get_vocab().items()}
     dictionary = {
-        token: idx for token, idx in dictionary.items() if 0 <= idx < emission_vocab_size
+        k.lower(): v for k, v in tokenizer.get_vocab().items()
+        if 0 <= v < emission_vocab_size
     }
     dictionary["<star>"] = emission_vocab_size
     return dictionary

--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -143,11 +143,11 @@ def load_audio(audio_file: str, dtype: torch.dtype, device: str):
 
 
 def generate_emissions(
-    model,
-    audio_waveform: torch.Tensor,
-    window_length=30,
-    context_length=2,
-    batch_size=4,
+        model,
+        audio_waveform: torch.Tensor,
+        window_length=30,
+        context_length=2,
+        batch_size=4,
 ):
     batch_size = max(batch_size, 1)
     window = int(window_length * SAMPLING_FREQ)
@@ -192,11 +192,11 @@ def generate_emissions(
 
 
 def forced_align(
-    log_probs: np.ndarray,
-    targets: np.ndarray,
-    input_lengths: Optional[np.ndarray] = None,
-    target_lengths: Optional[np.ndarray] = None,
-    blank: int = 0,
+        log_probs: np.ndarray,
+        targets: np.ndarray,
+        input_lengths: Optional[np.ndarray] = None,
+        target_lengths: Optional[np.ndarray] = None,
+        blank: int = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     r"""Align a CTC label sequence to an emission.
     Args:
@@ -234,7 +234,7 @@ def forced_align(
         raise ValueError(f"targets Tensor shouldn't contain blank index. Found {targets}.")
     if blank >= log_probs.shape[-1] or blank < 0:
         raise ValueError("blank must be within [0, log_probs.shape[-1])")
-    if np.max(targets) >= log_probs.shape[-1] and np.min(targets) >= 0:
+    if np.max(targets) >= log_probs.shape[-1] or np.min(targets) < 0:
         raise ValueError("targets values must be within [0, log_probs.shape[-1])")
     assert log_probs.dtype == np.float32, "log_probs must be float32"
 
@@ -246,21 +246,32 @@ def forced_align(
     return paths, scores
 
 
+def _build_alignment_dictionary(tokenizer, emission_vocab_size: int) -> dict[str, int]:
+    dictionary = {k.lower(): v for k, v in tokenizer.get_vocab().items()}
+    dictionary = {
+        token: idx for token, idx in dictionary.items() if 0 <= idx < emission_vocab_size
+    }
+    dictionary["<star>"] = emission_vocab_size
+    return dictionary
+
+
 def get_alignments(
-    emissions: torch.Tensor,
-    tokens: list,
-    tokenizer,
+        emissions: torch.Tensor,
+        tokens: list,
+        tokenizer,
 ):
     assert len(tokens) > 0, "Empty transcript"
 
-    dictionary = tokenizer.get_vocab()
-    dictionary = {k.lower(): v for k, v in dictionary.items()}
-    dictionary["<star>"] = len(dictionary)
+    emission_vocab_size = emissions.size(-1) - 1
+    dictionary = _build_alignment_dictionary(tokenizer, emission_vocab_size)
 
-    # Force Alignment
     token_indices = [dictionary[c] for c in " ".join(tokens).split(" ") if c in dictionary]
 
     blank_id = dictionary.get("<blank>", tokenizer.pad_token_id)
+    if blank_id >= emissions.size(-1) or blank_id < 0:
+        raise ValueError(
+            f"blank token index {blank_id} is outside the emission vocabulary of size {emissions.size(-1)}"
+        )
 
     if not emissions.is_cpu:
         emissions = emissions.cpu()
@@ -279,18 +290,18 @@ def get_alignments(
 
 
 def load_alignment_model(
-    device: str,
-    model_path: str = "MahmoudAshraf/mms-300m-1130-forced-aligner",
-    attn_implementation: str = None,
-    dtype: torch.dtype = torch.float32,
+        device: str,
+        model_path: str = "MahmoudAshraf/mms-300m-1130-forced-aligner",
+        attn_implementation: str = None,
+        dtype: torch.dtype = torch.float32,
 ):
     if attn_implementation is None:
         if version.parse(transformers_version) < version.parse("4.41.0"):
             attn_implementation = "eager"
         elif (
-            is_flash_attn_2_available()
-            and device == "cuda"
-            and dtype in [torch.float16, torch.bfloat16]
+                is_flash_attn_2_available()
+                and device == "cuda"
+                and dtype in [torch.float16, torch.bfloat16]
         ):
             attn_implementation = "flash_attention_2"
         else:

--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -270,7 +270,7 @@ def get_alignments(
         raise ValueError("No valid tokens found in the dictionary for the given transcript.")
 
     blank_id = dictionary.get("<blank>", tokenizer.pad_token_id)
-    if blank_id >= emissions.size(-1) or blank_id < 0:
+    if blank_id >= emission_vocab_size or blank_id < 0:
         raise ValueError(
             f"blank token index {blank_id} is outside the emission vocabulary of size {emissions.size(-1)}"
         )

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 import torchaudio.functional as F
 
+from ctc_forced_aligner import alignment_utils
 from ctc_forced_aligner.alignment_utils import forced_align
 
 
@@ -26,3 +27,34 @@ def test_alignment(logprobs_size, vocab_size, targets_size):
 
     num_mismatches = np.sum(ctc_alignment[0] != torch_alignment[0].numpy())
     assert num_mismatches <= 1
+
+
+def test_get_alignments_uses_emission_vocab_size_for_star(monkeypatch):
+    class DummyTokenizer:
+        pad_token_id = 1
+
+        def get_vocab(self):
+            return {
+                "<blank>": 0,
+                "<pad>": 1,
+                "a": 2,
+                "b": 3,
+                "|": 4,
+            }
+
+    captured = {}
+
+    def fake_forced_align(log_probs, targets, blank=0, **kwargs):
+        captured["log_probs_shape"] = log_probs.shape
+        captured["targets"] = targets.copy()
+        captured["blank"] = blank
+        return targets.copy(), np.zeros((targets.shape[-1],), dtype=np.float32)
+
+    monkeypatch.setattr(alignment_utils, "forced_align", fake_forced_align)
+
+    emissions = torch.zeros((8, 5), dtype=torch.float32)
+    alignment_utils.get_alignments(emissions, ["<star>", "a"], DummyTokenizer())
+
+    assert captured["targets"].tolist() == [[4, 2]]
+    assert captured["log_probs_shape"][-1] == 5
+    assert captured["blank"] == 0


### PR DESCRIPTION
# Proposed upstream fix for `ctc-forced-aligner`

## Problem
`get_alignments()` currently derives the synthetic `<star>` token index from `len(tokenizer.get_vocab())`.
That is unsafe when the tokenizer exposes added/special tokens whose ids are **outside** the model's emission vocabulary.

For `MahmoudAshraf/mms-300m-1130-forced-aligner`, the model config reports `vocab_size: 31`, while the tokenizer config declares a `word_delimiter_token` of `|` in addition to the core vocab. In that situation, using `len(dictionary)` for `<star>` can place `<star>` one step past the final valid class index.

Symptom:

```text
ValueError: targets values must be within [0, log_probs.shape[-1])
```

## Fix strategy
1. Derive the usable tokenizer dictionary from the emission vocabulary, not from raw tokenizer size.
2. Filter tokenizer ids to `< emission_vocab_size`.
3. Reserve the appended last class (`emission_vocab_size`) for `<star>`.
4. Tighten the target-range validation check from `and` to `or`.
5. Add a regression test for the tokenizer-extra-token case.

### What changed
- build the alignment dictionary from ids that are actually representable by the emissions
- reserve `emissions.size(-1) - 1` for the appended `<star>` class
- add a guard for invalid blank ids
- fix the target-range validation logic so negative ids are rejected too
- add a regression test covering a tokenizer that exposes an extra token outside the emission vocab

### Why this is safe
`generate_emissions()` already appends exactly one extra class for `<star>`, so the `<star>` id should be derived from the emission tensor, not from tokenizer cardinality.
