### PR TITLE
Bound CUDA memory during emission generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ alignment_model, alignment_tokenizer = load_alignment_model(
     dtype=torch.float16 if device == "cuda" else torch.float32,
 )
 
-audio_waveform = load_audio(audio_path, alignment_model.dtype, alignment_model.device)
+# Keep the complete waveform and emissions on CPU; only each inference batch uses CUDA.
+audio_waveform = load_audio(audio_path, alignment_model.dtype, "cpu")
 
 
 with open(text_path, "r") as f:
@@ -247,4 +248,3 @@ This project is licensed under the BSD License, note that the default model has 
 ### Acknowledgements
 
 This project is based on the work of FAIR MMS team.
-

--- a/ctc_forced_aligner/align.py
+++ b/ctc_forced_aligner/align.py
@@ -134,7 +134,8 @@ def cli():
         TORCH_DTYPES[args.compute_dtype],
     )
 
-    audio_waveform = load_audio(args.audio_path, model.dtype, model.device)
+    # Keep the complete waveform and emissions on CPU; only each inference batch uses CUDA.
+    audio_waveform = load_audio(args.audio_path, model.dtype, "cpu")
     emissions, stride = generate_emissions(
         model, audio_waveform, args.window_size, args.context_size, args.batch_size
     )

--- a/ctc_forced_aligner/alignment_utils.py
+++ b/ctc_forced_aligner/alignment_utils.py
@@ -140,6 +140,12 @@ def generate_emissions(
     context_length=2,
     batch_size=4,
 ):
+    """Generate CTC emissions while retaining only one inference batch at a time.
+
+    The returned tensor remains on ``audio_waveform.device`` for compatibility. Keeping
+    the waveform on CPU therefore bounds accelerator memory to the model, the current
+    inference batch, and its logits.
+    """
     batch_size = max(batch_size, 1)
     ratio = model.config.inputs_to_logits_ratio  # 320 for wav2vec2/MMS
     window = int(window_length * SAMPLING_FREQ)
@@ -152,35 +158,89 @@ def generate_emissions(
 
     if audio_waveform.size(0) < window:
         extension = 0
-        context = 0
-        input_tensor = audio_waveform.unsqueeze(0)
+        total_windows = 1
+        total_frames = None
     else:
-        # batching the input tensor and including a context
-        # before and after the input tensor
-        extension = math.ceil(audio_waveform.size(0) / window) * window - audio_waveform.size(0)
-        padded_waveform = torch.nn.functional.pad(audio_waveform, (context, context + extension))
-        input_tensor = padded_waveform.unfold(0, window + 2 * context, window)
+        total_windows = math.ceil(audio_waveform.size(0) / window)
+        extension = total_windows * window - audio_waveform.size(0)
+        total_frames = total_windows * window_frames - extension // ratio
 
-    # Batched Inference
-    emissions_arr = []
+    try:
+        model_parameter = next(model.parameters())
+    except StopIteration as error:
+        raise ValueError("The alignment model must have at least one parameter") from error
+    model_device = model_parameter.device
+    model_dtype = model_parameter.dtype
+    output_device = audio_waveform.device
+    effective_batch_size = batch_size
+    emissions = None
+    write_offset = 0
+    first_window = 0
+
     with torch.inference_mode():
-        for i in range(0, input_tensor.size(0), batch_size):
-            input_batch = input_tensor[i : i + batch_size]
-            emissions_ = model(input_batch).logits
-            emissions_arr.append(emissions_)
+        while first_window < total_windows:
+            window_count = min(effective_batch_size, total_windows - first_window)
+            input_batch = None
+            logits = None
+            batch_emissions = None
+            try:
+                if audio_waveform.size(0) < window:
+                    input_batch = audio_waveform.unsqueeze(0)
+                else:
+                    batch_start = first_window * window - context
+                    batch_end = (first_window + window_count) * window + context
+                    source_start = max(0, batch_start)
+                    source_end = min(audio_waveform.size(0), batch_end)
+                    input_batch = torch.nn.functional.pad(
+                        audio_waveform[source_start:source_end],
+                        (source_start - batch_start, batch_end - source_end),
+                    )
+                    input_batch = input_batch.unfold(0, window + 2 * context, window)
 
-    emissions = torch.cat(emissions_arr, dim=0)
-    if context > 0:
-        emissions = emissions[:, context_frames : context_frames + window_frames]
-    emissions = emissions.flatten(0, 1)
+                input_batch = input_batch.to(device=model_device, dtype=model_dtype)
+                logits = model(input_batch).logits
 
-    if extension > 0:
-        emissions = emissions[: -(extension // ratio)]
+                if audio_waveform.size(0) >= window:
+                    required_frames = context_frames + window_frames
+                    if logits.size(1) < required_frames:
+                        raise RuntimeError(
+                            "Model returned too few frames for the configured window"
+                        )
+                    logits = logits[:, context_frames:required_frames]
 
-    emissions = torch.log_softmax(emissions, dim=-1)
-    emissions = torch.cat(
-        [emissions, torch.zeros(emissions.size(0), 1).to(emissions.device)], dim=1
-    )  # adding a star token dimension
+                batch_emissions = torch.log_softmax(logits.flatten(0, 1), dim=-1)
+            except torch.cuda.OutOfMemoryError:
+                if window_count == 1:
+                    raise
+                effective_batch_size = max(1, window_count // 2)
+                del input_batch, logits, batch_emissions
+                if model_device.type == "cuda":
+                    torch.cuda.empty_cache()
+                continue
+
+            if total_frames is None:
+                total_frames = batch_emissions.size(0)
+            if emissions is None:
+                emissions = torch.empty(
+                    (total_frames, batch_emissions.size(-1) + 1),
+                    dtype=torch.float32,
+                    device=output_device,
+                )
+                emissions[:, -1] = 0
+
+            frame_count = min(batch_emissions.size(0), total_frames - write_offset)
+            emissions[write_offset : write_offset + frame_count, :-1].copy_(
+                batch_emissions[:frame_count].to(output_device, dtype=torch.float32)
+            )
+            write_offset += frame_count
+            first_window += window_count
+            del input_batch, logits, batch_emissions
+
+    if emissions is None or write_offset != total_frames:
+        raise RuntimeError(
+            f"Emission assembly wrote {write_offset} frames; expected {total_frames}"
+        )
+
     stride = ratio * 1000 / SAMPLING_FREQ
 
     return emissions, stride

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -1,0 +1,180 @@
+import math
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torchaudio.functional as F
+
+from ctc_forced_aligner.alignment_utils import SAMPLING_FREQ, generate_emissions
+
+RATIO = 320
+WINDOW = SAMPLING_FREQ
+CONTEXT = SAMPLING_FREQ // 5
+
+
+class DummyCTCModel(torch.nn.Module):
+    def __init__(self, fail_on_call=None):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.tensor(0.0))
+        self.config = SimpleNamespace(inputs_to_logits_ratio=RATIO)
+        self.calls = []
+        self.fail_on_call = fail_on_call
+
+    def forward(self, values):
+        self.calls.append(values.detach().clone())
+        if len(self.calls) == self.fail_on_call:
+            raise torch.cuda.OutOfMemoryError("synthetic OOM")
+        frame_count = values.size(1) // RATIO
+        frames = values[:, : frame_count * RATIO].reshape(values.size(0), frame_count, RATIO)
+        means = frames.mean(dim=-1)
+        logits = torch.stack((means, -means, means.square() / 2), dim=-1)
+        return SimpleNamespace(logits=logits)
+
+
+def reference_generate_emissions(model, audio, batch_size):
+    window = WINDOW
+    context = CONTEXT
+    context_frames = context // RATIO
+    window_frames = window // RATIO
+
+    if audio.size(0) < window:
+        extension = 0
+        context = 0
+        input_tensor = audio.unsqueeze(0)
+    else:
+        extension = math.ceil(audio.size(0) / window) * window - audio.size(0)
+        padded = torch.nn.functional.pad(audio, (context, context + extension))
+        input_tensor = padded.unfold(0, window + 2 * context, window)
+
+    batches = []
+    with torch.inference_mode():
+        for index in range(0, input_tensor.size(0), batch_size):
+            batches.append(model(input_tensor[index : index + batch_size]).logits)
+    emissions = torch.cat(batches)
+    if context > 0:
+        emissions = emissions[:, context_frames : context_frames + window_frames]
+    emissions = emissions.flatten(0, 1)
+    extension_frames = extension // RATIO
+    if extension_frames > 0:
+        emissions = emissions[:-extension_frames]
+    emissions = torch.log_softmax(emissions, dim=-1)
+    return torch.cat((emissions, torch.zeros(emissions.size(0), 1, device=emissions.device)), dim=1)
+
+
+@pytest.mark.parametrize(
+    "sample_count",
+    [
+        WINDOW // 2,
+        WINDOW - 1,
+        WINDOW,
+        WINDOW + 1,
+        2 * WINDOW - 321,
+        2 * WINDOW - 320,
+        2 * WINDOW - 319,
+        2 * WINDOW - 1,
+        2 * WINDOW,
+        3 * WINDOW + 640,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 8])
+def test_generate_emissions_matches_reference(sample_count, batch_size):
+    audio = torch.linspace(-1, 1, sample_count)
+    expected = reference_generate_emissions(DummyCTCModel(), audio, batch_size)
+
+    emissions, stride = generate_emissions(
+        DummyCTCModel(),
+        audio,
+        window_length=1,
+        context_length=0.2,
+        batch_size=batch_size,
+    )
+
+    torch.testing.assert_close(emissions, expected, rtol=0, atol=0)
+    assert emissions.dtype == torch.float32
+    assert emissions.device == audio.device
+    assert emissions.is_contiguous()
+    assert torch.count_nonzero(emissions[:, -1]) == 0
+    assert stride == 20.0
+
+
+def test_subframe_extension_does_not_empty_emissions():
+    audio = torch.zeros(2 * WINDOW - 1)
+    emissions, _ = generate_emissions(DummyCTCModel(), audio, window_length=1, context_length=0.2)
+
+    assert emissions.size(0) == math.ceil(audio.size(0) / RATIO)
+
+
+def test_emissions_preserve_downstream_forced_alignment():
+    audio = torch.linspace(-1, 1, 2 * WINDOW + RATIO)
+    expected = reference_generate_emissions(DummyCTCModel(), audio, batch_size=2)
+    actual, _ = generate_emissions(
+        DummyCTCModel(), audio, window_length=1, context_length=0.2, batch_size=2
+    )
+    targets = torch.tensor([[1, 2, 1, 2]], dtype=torch.int64)
+
+    expected_path, expected_scores = F.forced_align(expected.unsqueeze(0), targets)
+    actual_path, actual_scores = F.forced_align(actual.unsqueeze(0), targets)
+
+    torch.testing.assert_close(actual_path, expected_path, rtol=0, atol=0)
+    torch.testing.assert_close(actual_scores, expected_scores, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cpu_audio_is_processed_on_gpu_without_changing_output_device():
+    audio = torch.linspace(-1, 1, 2 * WINDOW + RATIO, dtype=torch.float16)
+    reference_model = DummyCTCModel().cuda().half()
+    candidate_model = DummyCTCModel().cuda().half()
+    expected = reference_generate_emissions(reference_model, audio.cuda(), batch_size=2).cpu()
+
+    actual, _ = generate_emissions(
+        candidate_model,
+        audio,
+        window_length=1,
+        context_length=0.2,
+        batch_size=2,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.device.type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cuda_audio_preserves_cuda_output_compatibility():
+    audio = torch.linspace(-1, 1, 2 * WINDOW + RATIO, device="cuda", dtype=torch.float16)
+    expected = reference_generate_emissions(DummyCTCModel().cuda().half(), audio, batch_size=2)
+
+    actual, _ = generate_emissions(
+        DummyCTCModel().cuda().half(),
+        audio,
+        window_length=1,
+        context_length=0.2,
+        batch_size=2,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.device.type == "cuda"
+
+
+def test_oom_reduces_remaining_batches_without_recomputing_completed_windows():
+    audio = torch.arange(8 * WINDOW, dtype=torch.float32)
+    failing_model = DummyCTCModel(fail_on_call=2)
+    expected, _ = generate_emissions(
+        DummyCTCModel(), audio, window_length=1, context_length=0.2, batch_size=4
+    )
+
+    emissions, _ = generate_emissions(
+        failing_model, audio, window_length=1, context_length=0.2, batch_size=4
+    )
+
+    torch.testing.assert_close(emissions, expected, rtol=0, atol=0)
+    assert [batch.size(0) for batch in failing_model.calls] == [4, 4, 2, 2]
+    torch.testing.assert_close(failing_model.calls[2], failing_model.calls[1][:2], rtol=0, atol=0)
+    torch.testing.assert_close(failing_model.calls[3], failing_model.calls[1][2:], rtol=0, atol=0)
+
+
+def test_oom_with_one_window_is_not_retried():
+    model = DummyCTCModel(fail_on_call=1)
+    with pytest.raises(torch.cuda.OutOfMemoryError, match="synthetic OOM"):
+        generate_emissions(model, torch.zeros(WINDOW // 2), window_length=1)
+    assert len(model.calls) == 1


### PR DESCRIPTION
> **AI-generated PR disclosure:** This is an AI-generated pull request, prepared after three days of implementation, testing, benchmarking, and review in our [Cohere Arabic batch-inference project](https://github.com/AliOsm/cohere-transcribe-arabic-batch-inference). The implementation was then isolated against current `ctc-forced-aligner` main and independently reviewed before publication.

## Summary

`generate_emissions()` currently pads the complete recording on its input device and retains every batch of logits until inference finishes. Accelerator memory therefore grows with recording duration even though model inference is already windowed.

This PR:

- constructs only the source slab needed by the current inference batch;
- writes normalized emissions into their final tensor as each batch completes;
- keeps the CLI and documented Python path's complete waveform and output on CPU while moving only the current batch to the model;
- halves the effective batch size after a CUDA OOM and resumes from the first unfinished window;
- releases each batch's tensors before starting the next batch;
- preserves the existing public signature and return-device behavior for Python callers;
- fixes the sub-stride padding case where `emissions[:-0]` could return an empty tensor.

This addresses the long-recording alignment-memory portion of #89. It does not change diarization.

## Correctness

The baseline was current upstream main at `11855d1de76af2b490dd2e8e2db2661805ae90a0`.

| Validation set | Precision | Files | Compared values | Result |
| --- | --- | ---: | ---: | --- |
| Balanced Arabic set: Casablanca, Common Voice 18, FLEURS, Quran, SADA22 | FP16 | 500 | 8,045,248 | exact, zero mismatches |
| Same balanced set | FP32 | 500 | 8,045,248 | exact, zero mismatches |
| 69m20.679s Arabic recording | FP16 | 1 | 6,657,088 | exact, zero mismatches |
| Same recording | FP32 | 1 | 6,657,088 | exact, zero mismatches |

The balanced set contains 5,035.7145 seconds of audio, with 100 clips from each dataset. Tests also compare downstream TorchAudio forced-alignment paths and scores, window boundaries, exact/sub-stride padding, CPU and CUDA output placement, and OOM recovery without recomputing completed windows.

## Memory and runtime

Measured on an RTX 3060 12 GB with the MMS aligner in FP16 and batch size 4. The longer inputs repeat the same recording to expose duration scaling. Timings cover emission generation only.

| Audio | Baseline time | PR time | Baseline peak CUDA allocated | PR peak CUDA allocated | Change |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 69m20.679s | 16.109 s | 16.235 s | 2.520 GiB | 2.263 GiB | -10.2% |
| 2h18m41s | 32.214 s | 32.286 s | 2.781 GiB | 2.263 GiB | -18.7% |
| 4h37m23s | 64.309 s | 63.931 s | 3.304 GiB | 2.263 GiB | -31.5% |

Peak allocated CUDA memory stays flat as duration increases. Runtime remains effectively unchanged. At 4x duration, peak reserved CUDA memory also falls from 3.959 GiB to 2.898 GiB.

## Validation

```text
Ruff lint: passed
Ruff format check: passed
Focused emission tests: 36 passed (CUDA included)
Wheel build: passed
Installed-wheel import smoke test: passed
Independent implementation review: no remaining blocker
```

The repository's complete legacy suite still hits the native aligner crash reported in #94 on four existing `tests/test_alignment.py` cases. I reproduced that failure on unmodified current main; this PR does not touch the native alignment kernel. A separate focused fix is being prepared for that issue.
