### PR TITLE
Grow compact backpointer storage for tight trellises

### DIFF
--- a/ctc_forced_aligner/forced_align_impl.cpp
+++ b/ctc_forced_aligner/forced_align_impl.cpp
@@ -19,9 +19,8 @@ void forced_align_impl(
   const auto S = 2 * L + 1;
   std::vector<scalar_t> alphas(2 * S, kNegInfinity);
 
-  // Replace backPtr tensor with two std::vector<bool>
-  // allocate memory based on the expected needed size which is approximately
-  // S * (T-L), we will use a safety margin of (T-L) to avoid reallocation
+  // Replace backPtr tensor with two std::vector<bool>. Allocate the expected
+  // common-case size, but allow the vectors to grow for tighter trellises.
   std::vector<unsigned long long> backPtr_offset(T - 1);
   std::vector<unsigned long long> backPtr_seek(T - 1);
 
@@ -70,6 +69,11 @@ void forced_align_impl(
     std::fill(alphas.begin() + curIdxOffset * S, alphas.begin() + (curIdxOffset + 1) * S, kNegInfinity);
     backPtr_seek[t - 1] = seek;
     backPtr_offset[t - 1] = start;
+    const auto requiredBackPtrSize = seek + end - start;
+    while (backPtrBit0.size() < requiredBackPtrSize) {
+      backPtrBit0.push_back(false);
+      backPtrBit1.push_back(false);
+    }
     if (start == 0) {
       alphas[curIdxOffset * S] = alphas[prevIdxOffset * S] + logProbs_data(batchIndex, t, blank);
       startloop += 1;
@@ -111,10 +115,11 @@ void forced_align_impl(
   for (auto t = T - 1; t > -1; t--) {
     auto lbl_idx = ltrIdx % 2 == 0 ? blank : targets_data(batchIndex, ltrIdx / 2);
     paths_data(batchIndex, t) = lbl_idx;
+    if (t == 0) {
+      break;
+    }
     // Calculate backPtr value from bits
-    auto t_minus_one = t - 1 >= 0 ? t - 1 : 0;
-    auto backPtr_idx = backPtr_seek[t_minus_one] +
-                       ltrIdx - backPtr_offset[t_minus_one];
+    auto backPtr_idx = backPtr_seek[t - 1] + ltrIdx - backPtr_offset[t - 1];
     ltrIdx -= (backPtrBit1[backPtr_idx] << 1) | backPtrBit0[backPtr_idx];
   }
 }

--- a/ctc_forced_aligner/forced_align_impl.cpp
+++ b/ctc_forced_aligner/forced_align_impl.cpp
@@ -70,9 +70,9 @@ void forced_align_impl(
     backPtr_seek[t - 1] = seek;
     backPtr_offset[t - 1] = start;
     const auto requiredBackPtrSize = seek + end - start;
-    while (backPtrBit0.size() < requiredBackPtrSize) {
-      backPtrBit0.push_back(false);
-      backPtrBit1.push_back(false);
+    if (backPtrBit0.size() < requiredBackPtrSize) {
+      backPtrBit0.resize(requiredBackPtrSize, false);
+      backPtrBit1.resize(requiredBackPtrSize, false);
     }
     if (start == 0) {
       alphas[curIdxOffset * S] = alphas[prevIdxOffset * S] + logProbs_data(batchIndex, t, blank);

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -6,6 +6,14 @@ import torchaudio.functional as F
 from ctc_forced_aligner.alignment_utils import forced_align
 
 
+def assert_matches_torchaudio(logprobs, targets):
+    ctc_paths, ctc_scores = forced_align(logprobs.numpy(), targets.numpy())
+    torch_paths, torch_scores = F.forced_align(logprobs, targets)
+
+    np.testing.assert_array_equal(ctc_paths, torch_paths.numpy())
+    np.testing.assert_array_equal(ctc_scores, torch_scores.squeeze(0).numpy())
+
+
 @pytest.mark.parametrize(
     "logprobs_size, vocab_size, targets_size",
     [
@@ -26,3 +34,22 @@ def test_alignment(logprobs_size, vocab_size, targets_size):
 
     num_mismatches = np.sum(ctc_alignment[0] != torch_alignment[0].numpy())
     assert num_mismatches <= 1
+
+
+@pytest.mark.parametrize(
+    "frames, target_values",
+    [
+        (21, list(range(1, 16))),
+        (1, [1]),
+        (15, list(range(1, 16))),
+        (7, [1, 1, 2, 2, 3]),
+        (155, [(index % 30) + 1 for index in range(86)]),
+        (300, [(index % 30) + 1 for index in range(80)]),
+    ],
+)
+def test_tight_trellis_matches_torchaudio(frames, target_values):
+    generator = torch.Generator().manual_seed(frames + len(target_values))
+    targets = torch.tensor([target_values], dtype=torch.int64)
+    logprobs = torch.randn((1, frames, 32), generator=generator).log_softmax(dim=-1)
+
+    assert_matches_torchaudio(logprobs, targets)


### PR DESCRIPTION
> **AI-generated PR disclosure:** This is an AI-generated pull request, prepared after three days of implementation, testing, benchmarking, and review in our [Cohere Arabic batch-inference project](https://github.com/AliOsm/cohere-transcribe-arabic-batch-inference). The native change was then isolated and independently reviewed before publication.

## Summary

This fixes #94 without replacing the compact backpointer layout:

- retain the existing `(S + 1) * (T - L)` common-case allocation and indexed hot path;
- before each trellis row, append zeroed bits only when that row exceeds the heuristic;
- preserve every transition comparison and tie-breaking branch;
- stop the one-frame backtrace after writing `t=0`, fixing the adjacent valid `T=1, L=1` case.

A literal per-state `push_back` prototype was correct but 42.1% slower on representative real shapes. Growing only the underestimated tail keeps normal inputs on the existing implementation.

## Real-data frequency

Using the maintained Uroman preprocessing and MMS tokenizer:

- Balanced 500 Arabic clips: 7/726 valid segments (0.96%) in 4/500 files. All seven were Quran samples containing the same 34-target ASR phrase; their logical shortfall was 6-31 bits.
- 69m20s recording: 0/378 valid segments.
- Combined: 7/1,104 valid segments (0.63%).

This is production-derived evidence for the frequency requested in #94, not a claim that 0.96% generalizes to arbitrary audio.

## Validation

- Candidate versus TorchAudio: exact paths and scores for 10,006/10,006 seeded valid cases.
- Candidate versus TorchAudio: exact paths and scores for 1,104/1,104 frozen valid Arabic segments across Casablanca, Common Voice, FLEURS, Quran, SADA22, and the long recording.
- Current main versus candidate: exact on all 8,443 logically safe synthetic cases and all 1,097 safe frozen segments.
- The three frozen invalid targets are still rejected.
- AddressSanitizer reproduces current main's failures at `T=21,L=15` and `T=1,L=1`; both candidate cases exit cleanly and match TorchAudio.
- All 22 repository alignment tests pass; Ruff lint/format, diff checks, wheel build, and installed-wheel smoke tests pass.

## Runtime

`g++ -O3 -DNDEBUG`, one pinned CPU core, 128 evenly sampled safe real shapes, 101 alternating-order rounds:

| Implementation | Median / 128 cases | Median / case |
| --- | ---: | ---: |
| Current main | 44.472 ms | 347.434 us |
| This PR | 44.300 ms | 346.091 us |

The -0.39% difference is measurement noise; the intended conclusion is no measurable hot-path regression.
